### PR TITLE
chore: set @wg-ecosystem as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @electron/wg-ecosystem


### PR DESCRIPTION
Forgot to add this when setting up the repo.