### PR TITLE
build: correct namespace for published orb

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -95,7 +95,7 @@ workflows:
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
-          orb_name: electron/node
+          orb_name: electronjs/node
           vcs_type: << pipeline.project.type >>
           pub_type: production
           # Ensure this job requires all test jobs and the pack job.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Node Orb
 
 [![CircleCI Build Status](https://circleci.com/gh/electron/node-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/electron/node-orb)
-[![CircleCI Orb Version](https://badges.circleci.com/orbs/electron/node.svg)](https://circleci.com/developer/orbs/orb/electron/node)
+[![CircleCI Orb Version](https://badges.circleci.com/orbs/electronjs/node.svg)](https://circleci.com/developer/orbs/orb/electronjs/node)
 [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/electron/node-orb/main/LICENSE)
 [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
@@ -9,7 +9,7 @@
 
 ## Usage
 
-For full usage guidelines, see the [orb registry listing](http://circleci.com/orbs/registry/orb/electron/node).
+For full usage guidelines, see the [orb registry listing](http://circleci.com/orbs/registry/orb/electronjs/node).
 
 ## License
 

--- a/src/examples/install_command.yml
+++ b/src/examples/install_command.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    node: electron/node@x.y.z
+    node: electronjs/node@x.y.z
   jobs:
     check-version:
       executor: node/macos

--- a/src/examples/install_job.yml
+++ b/src/examples/install_job.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    node: electron/node@x.y.z
+    node: electronjs/node@x.y.z
   workflows:
     check_node_version:
       jobs:

--- a/src/examples/test_command.yml
+++ b/src/examples/test_command.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    node: electron/node@x.y.z
+    node: electronjs/node@x.y.z
   jobs:
     test:
       executor: node/macos

--- a/src/examples/test_job.yml
+++ b/src/examples/test_job.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    node: electron/node@x.y.z
+    node: electronjs/node@x.y.z
   workflows:
     test:
       jobs:


### PR DESCRIPTION
The namespace for Electron orbs is actually `electronjs`.