### PR TITLE
feat: use current tag for Windows executor

### DIFF
--- a/src/executors/windows.yml
+++ b/src/executors/windows.yml
@@ -2,6 +2,6 @@ description: >
   Windows executor.
 
 machine:
-  image: windows-server-2022-gui:stable
+  image: windows-server-2022-gui:current
   resource_class: windows.medium
   shell: bash.exe


### PR DESCRIPTION
Not sure how `:stable` ended up in here originally, it's not a listed image tag on CircleCI's Windows images and resolves to an image from Oct 2022.