### PR TITLE
feat: support partial Node.js version strings

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -35,7 +35,9 @@ jobs:
         description: The executor to use for the job
         type: string
       node-version:
-        description: Specify the Node.js version to install
+        description: >
+          Specify the Node.js version to install. Can be a major version, a minor
+          version (e.g. 18.16), an exact version number, "latest" or "lts".
         type: string
       with-cache:
         default: true
@@ -47,7 +49,7 @@ jobs:
           node-version: << parameters.node-version >>
           with-cache: << parameters.with-cache >>
       - run:
-          command: '[ $(node -v) == "v<<parameters.node-version>>" ]'
+          command: '[ $(node -v) = "v$(cat ~/.node-js-version)" ]'
           name: Confirm Version
   run-tests:
     executor: << parameters.executor >>
@@ -62,7 +64,9 @@ jobs:
         description: The executor to use for the job
         type: string
       node-version:
-        description: Specify the Node.js version to install
+        description: >
+          Specify the Node.js version to install. Can be a major version, a minor
+          version (e.g. 18.16), an exact version number, "latest" or "lts".
         type: string
       use-test-steps:
         default: false
@@ -112,7 +116,10 @@ workflows:
                 - node/windows
               node-version:
                 - 18.14.0
-                - 16.19.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
               with-cache:
                 - false
                 - true
@@ -130,13 +137,16 @@ workflows:
                 - node/windows
               node-version:
                 - 18.14.0
-                - 16.19.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
               with-cache:
                 - false
                 - true
           post-steps:
             - run:
-                command: '[ $(node -v) == "v<<matrix.node-version>>" ]'
+                command: '[ $(node -v) = "v$(cat ~/.node-js-version)" ]'
                 name: Confirm Version
       - run-tests:
           filters: *filters
@@ -150,7 +160,10 @@ workflows:
                 - node/windows
               node-version:
                 - 18.14.0
-                - 16.19.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
               use-test-steps:
                 - false
                 - true
@@ -168,7 +181,10 @@ workflows:
                 - node/windows
               node-version:
                 - 18.14.0
-                - 16.19.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
               use-test-steps:
                 - false
                 - true

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -13,7 +13,9 @@ parameters:
     description: Install Yarn?
     type: boolean
   node-version:
-    description: Specify the Node.js version to install.
+    description: >
+      Specify the Node.js version to install. Can be a major version, a minor
+      version (e.g. 18.16), an exact version number, "latest" or "lts".
     type: string
   with-cache:
     default: true
@@ -24,11 +26,16 @@ steps:
   - run:
       command: <<include(scripts/install-nvm.sh)>>
       name: Install nvm
+  - run:
+      command: <<include(scripts/resolve-node-js-version.sh)>>
+      environment:
+        NODE_PARAM_VERSION: <<parameters.node-version>>
+      name: Resolve full Node.js version
   - when:
       condition: << parameters.with-cache >>
       steps:
         - restore_cache:
-            key: node-js-<<parameters.cache-version>>-{{ arch }}-{{ checksum "~/.nvm-version" }}-<<parameters.node-version>>
+            key: node-js-<<parameters.cache-version>>-{{ arch }}-{{ checksum "~/.nvm-version" }}-{{ checksum "~/.node-js-version" }}
         - run:
             command: <<include(scripts/restore-node-js-cache.sh)>>
             name: Restore cached Node.js
@@ -44,7 +51,7 @@ steps:
             command: <<include(scripts/prepare-node-js-cache.sh)>>
             name: Prepare Node.js cache
         - save_cache:
-            key: node-js-<<parameters.cache-version>>-{{ arch }}-{{ checksum "~/.nvm-version" }}-<<parameters.node-version>>
+            key: node-js-<<parameters.cache-version>>-{{ arch }}-{{ checksum "~/.nvm-version" }}-{{ checksum "~/.node-js-version" }}
             paths:
              - ~/.node-js-cache
   - when:

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -20,7 +20,9 @@ parameters:
     description: Steps to use as the checkout steps.
     type: steps
   node-version:
-    description: Specify the Node.js version to install.
+    description: >
+      Specify the Node.js version to install. Can be a major version, a minor
+      version (e.g. 18.16), an exact version number, "latest" or "lts".
     type: string
   override-ci-command:
     default: ''

--- a/src/examples/install_command.yml
+++ b/src/examples/install_command.yml
@@ -10,7 +10,9 @@ usage:
       executor: node/macos
       parameters:
         node-version:
-          description: Specify the Node.js version to install.
+          description: >
+            Specify the Node.js version to install. Can be a major version, a minor
+            version (e.g. 18.16), an exact version number, "latest" or "lts".
           type: string
       steps:
         - node/install:

--- a/src/examples/test_command.yml
+++ b/src/examples/test_command.yml
@@ -10,7 +10,9 @@ usage:
       executor: node/macos
       parameters:
         node-version:
-          description: Specify the Node.js version to install.
+          description: >
+            Specify the Node.js version to install. Can be a major version, a minor
+            version (e.g. 18.16), an exact version number, "latest" or "lts".
           type: string
       steps:
         - node/test:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -18,7 +18,9 @@ parameters:
     description: Install Yarn?
     type: boolean
   node-version:
-    description: Specify the Node.js version to install.
+    description: >
+      Specify the Node.js version to install. Can be a major version, a minor
+      version (e.g. 18.16), an exact version number, "latest" or "lts".
     type: string
   with-cache:
     default: true

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -25,7 +25,9 @@ parameters:
     description: The executor to use for the job.
     type: executor
   node-version:
-    description: Specify the Node.js version to install.
+    description: >
+      Specify the Node.js version to install. Can be a major version, a minor
+      version (e.g. 18.16), an exact version number, "latest" or "lts".
     type: string
   override-ci-command:
     default: ''

--- a/src/scripts/resolve-node-js-version.sh
+++ b/src/scripts/resolve-node-js-version.sh
@@ -1,0 +1,30 @@
+set -eo pipefail
+
+NODE_RELEASES="https://nodejs.org/download/release/index.json"
+VERSION_KEY_REGEX="\"version\":\s*\"v[0-9]+\.[0-9]+\.[0-9]+\""
+VERSION_NUMBER_REGEX="[0-9]+\.[0-9]+\.[0-9]+"
+
+if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
+    # Windows has its own sort.exe, which we do not want
+    SORT="/usr/bin/sort"
+else
+    SORT="sort"
+fi
+
+
+case $NODE_PARAM_VERSION in
+  latest)
+    RESOLVED_VERSION=$(curl -fs "$NODE_RELEASES" | grep -Eo "$VERSION_KEY_REGEX" - | grep -Eo "$VERSION_NUMBER_REGEX" | $SORT -V | tail -n1)
+    ;;
+
+  lts)
+    RESOLVED_VERSION=$(curl -fs "$NODE_RELEASES" | tr -d '\n' | grep -Eo '"version":\s*"v[0-9]+\.[0-9]+\.[0-9]+",[^}]*"lts":\s*"' - | grep -Eo "$VERSION_KEY_REGEX" | grep -Eo "$VERSION_NUMBER_REGEX" | $SORT -V | tail -n1)
+    ;;
+
+  *)
+    RESOLVED_VERSION=$(curl -fs "$NODE_RELEASES" | grep -Eo "\"version\":\s*\"v${NODE_PARAM_VERSION}[.0-9]*\"" - | grep -Eo "$VERSION_NUMBER_REGEX" | $SORT -V | tail -n1)
+    ;;
+esac
+
+# Store the full version so cache keys can easily use it
+echo "$RESOLVED_VERSION" > ~/.node-js-version;


### PR DESCRIPTION
This *kinda* works in practice already, with the large caveat that the cache keys will use the version string provided, so "lts" would cache as whatever the LTS version was at that time and never update when new releases come out unless you change your cache key prefix.

This PR adds official support and expands the test matrix to cover it, by first resolving the provided version string to a full version and then using that in the cache key (well, the checksum of it, since CircleCI doesn't have a way to use variables in the cache key 🤷).