### PR TITLE
fix: confirm nvm-windows install succeeded

### DIFF
--- a/src/scripts/install-node.sh
+++ b/src/scripts/install-node.sh
@@ -10,7 +10,18 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
         nvm install lts;
     fi
 
+    nvm use newest;
     echo 'nvm use newest &>/dev/null' >> "$BASH_ENV";
+
+    # Confirm that the Node.js version matches what is expected
+    # using the fully resolved version number from the other
+    # script, 'resolve-node-js-version.sh'. This is necessary
+    # because nvm-windows will silently fail if there's an error
+    # while downloading (and Node.js servers are unstable lately)
+    # See: https://github.com/coreybutler/nvm-windows/issues/738
+    if [ "$(node -v)" != "v$(cat ~/.node-js-version)" ]; then
+        exit 1;
+    fi
 else
     # Copyright (c) 2019 CircleCI Public
     # (derived from https://github.com/CircleCI-Public/node-orb/blob/master/src/scripts/install-nvm.sh)


### PR DESCRIPTION
Unfortunately `nvm-windows` does not correctly set exit codes on failure during install, so we need to manually check. Failing to detect these failures can corrupt the cache apparently, leading to a permanently broken job, [see this `electron/chromedriver` CircleCI job for an example](https://app.circleci.com/pipelines/github/electron/chromedriver/207/workflows/259b6582-36e3-4985-8a68-d50133f5a6c6/jobs/1045).

Upstream issue is closed and unlikely to be addressed: https://github.com/coreybutler/nvm-windows/issues/738