### PR TITLE
feat: switch macOS executor to macos.m1.medium.gen1

### DIFF
--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -4,4 +4,4 @@ description: >
 macos:
   xcode: "14.3.0"
 
-resource_class: macos.x86.medium.gen2
+resource_class: macos.m1.medium.gen1


### PR DESCRIPTION
BREAKING CHANGE: macOS executor is now ARM