### PR TITLE
feat!: migrate from x86.medium.gen2 executor to m1.medium.gen1

### DIFF
--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -4,4 +4,4 @@ description: >
 macos:
   xcode: "14.3.0"
 
-resource_class: macos.x86.medium.gen2
+resource_class: macos.m1.medium.gen1


### PR DESCRIPTION
BREAKING CHANGE: x86.medium.gen2 executor now replaced with m1.medium.gen1

[CircleCI is deprecating their Intel-based ("Gen1" and "Gen2") macOS resources](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718?page=2) and will only offer Apple silicon-based resources starting June 28, 2024. gen1 processors have been already deprecated as of  10/2/23. 

We should update Electron’s ecosystem packages to `macos.m1.{medium | large}.gen1` resources to avoid build failures after the deprecation date.

I'm of the opinion that we can and should merge this before December (when the executor reaches free-tier) to catch any outlier behaviours that may arise- as an open source project we get some free credits from CircleCI, and since e/e already uses the arm runners, most new usage would come from `electron/forge` and `electron/fiddle` which see far fewer PRs than `e/e` does, so I don't think this change comes at much monetary cost, if at all.


## cost
* M1 Medium
    * resource class tag: macos.m1.medium.gen1
    * 4 vCPU
    * 6GB RAM
    * 150 credits / minute
    * This runner will transition to the free plan in December, replacing the current intel x86 runner

