### PR TITLE
feat: add install-rosetta command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -51,6 +51,17 @@ jobs:
       - run:
           command: '[ $(node -v) = "v$(cat ~/.node-js-version)" ]'
           name: Confirm Version
+  install-rosetta:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        description: The executor to use for the job
+        type: string
+    steps:
+      - node/install-rosetta
+      - run:
+          command: '[ $(/usr/bin/pgrep -q oahd && echo Yes || echo No) = "Yes" ]'
+          name: Confirm Rosetta install
   run-tests:
     executor: << parameters.executor >>
     parameters:
@@ -148,6 +159,12 @@ workflows:
             - run:
                 command: '[ $(node -v) = "v$(cat ~/.node-js-version)" ]'
                 name: Confirm Version
+      - install-rosetta:
+          filters: *filters
+          matrix:
+            parameters:
+              executor:
+                - node/macos
       - run-tests:
           filters: *filters
           matrix:
@@ -222,6 +239,7 @@ workflows:
           requires:
             - orb-tools/pack
             - check-version
+            - install-rosetta
             - check-version-job
             - run-tests
             - run-tests-job

--- a/src/commands/install-rosetta.yml
+++ b/src/commands/install-rosetta.yml
@@ -1,0 +1,6 @@
+description:
+  Install Rosetta 2 on Apple Silicon executors
+steps:
+  - run:
+      name: Installing Rosetta 2
+      command: << include(scripts/install-rosetta.sh) >>

--- a/src/examples/install_rosetta_command.yml
+++ b/src/examples/install_rosetta_command.yml
@@ -1,0 +1,19 @@
+description: >
+  Example using the install-rosetta command.
+
+usage:
+  version: 2.1
+  orbs:
+    node: electronjs/node@x.y.z
+  jobs:
+    install-rosetta:
+      executor: node/macos
+      steps:
+        - node/install-rosetta
+        - run:
+            command: '[ $(/usr/bin/pgrep -q oahd && echo Yes || echo No) = "Yes" ]'
+            name: Confirm Rosetta install
+  workflows:
+    install_rosetta:
+      jobs:
+        - install-rosetta

--- a/src/scripts/install-rosetta.sh
+++ b/src/scripts/install-rosetta.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [ "$(uname -m)" = "arm64" ]; then
+    /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+else
+    echo "Rosetta 2 can only be installed on Apple Silicon!"
+    exit 1
+fi


### PR DESCRIPTION
[Node orb v2](https://github.com/electron/node-orb/releases/tag/v2.0.0) replaced our CircleCI intel runners with arm-based m1 runners. In order to support running intel binaries on arm runners, we should expose a command to install rosetta on our image.