### PR TITLE
feat: specify arch for Node.js install

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -25,6 +25,12 @@ jobs:
   check-version:
     executor: << parameters.executor >>
     parameters:
+      arch:
+        default: ""
+        description: >
+          Arch to use for executing the Bash script - only supported for installing
+          x86_64 Node.js on macOS ARM64 (must install Rosetta first).
+        type: string
       cache-version:
         default: v1
         description: >
@@ -45,12 +51,19 @@ jobs:
         type: boolean
     steps:
       - node/install:
+          arch: << parameters.arch >>
           cache-version: << parameters.cache-version >>
           node-version: << parameters.node-version >>
           with-cache: << parameters.with-cache >>
       - run:
           command: 'echo "Installed version: $(node -v)" && echo "Expected version: v$(cat ~/.node-js-version)" && [ $(node -v) = "v$(cat ~/.node-js-version)" ]'
           name: Confirm Version
+      - when:
+          condition: << parameters.arch >>
+          steps:
+            - run:
+                command: 'echo "Installed arch: $(node -p "process.arch === \"x64\" ? \"x86_64\" : process.arch")" && echo "Expected arch: << parameters.arch >>" && [ $(node -p "process.arch === \"x64\" ? \"x86_64\" : process.arch") = "<< parameters.arch >>" ]'
+                name: Confirm Arch
   install-rosetta:
     executor: << parameters.executor >>
     parameters:
@@ -65,6 +78,12 @@ jobs:
   run-tests:
     executor: << parameters.executor >>
     parameters:
+      arch:
+        default: ""
+        description: >
+          Arch to use for executing the Bash script - only supported for installing
+          x86_64 Node.js on macOS ARM64 (must install Rosetta first).
+        type: string
       cache-version:
         default: v1
         description: >
@@ -89,6 +108,7 @@ jobs:
           name: Confirm Tests Haven't Run Yet
       - node/test:
           app-dir: ~/project/sample
+          arch: << parameters.arch >>
           cache-version: << parameters.cache-version >>
           node-version: << parameters.node-version >>
           post-node-js-install-steps:
@@ -118,13 +138,14 @@ workflows:
       - check-version:
           filters: *filters
           matrix:
+            alias: check-version
             parameters:
               cache-version:
                 - v3
               executor:
+                - node/windows
                 - node/linux
                 - node/macos
-                - node/windows
               node-version:
                 - 18.14.0
                 - '16.19'
@@ -134,6 +155,29 @@ workflows:
               with-cache:
                 - false
                 - true
+      - check-version:
+          filters: *filters
+          matrix:
+            alias: check-version-with-arch
+            parameters:
+              arch:
+                - arm64
+                - x86_64
+              cache-version:
+                - v3
+              executor:
+                - node/macos
+              node-version:
+                - 18.14.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
+              with-cache:
+                - false
+                - true
+          pre-steps:
+            - node/install-rosetta
       - node/install:
           install-yarn: false
           filters: *filters
@@ -142,10 +186,10 @@ workflows:
             parameters:
               cache-version:
                 - v3
-              executor:
+              executor: 
+                - node/windows
                 - node/linux
                 - node/macos
-                - node/windows
               node-version:
                 - 18.14.0
                 - '16.19'
@@ -159,6 +203,38 @@ workflows:
             - run:
                 command: 'echo "Installed version: $(node -v)" && echo "Expected version: v$(cat ~/.node-js-version)" && [ $(node -v) = "v$(cat ~/.node-js-version)" ]'
                 name: Confirm Version
+      - node/install:
+          name: node/install-<< matrix.arch >>-<< matrix.cache-version >>-<< matrix.executor >>-<< matrix.node-version >>-<< matrix.with-cache >>
+          install-yarn: false
+          filters: *filters
+          matrix:
+            alias: check-version-job-with-arch
+            parameters:
+              arch:
+                - arm64
+                - x86_64
+              cache-version:
+                - v3
+              executor:
+                - node/macos
+              node-version:
+                - 18.14.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
+              with-cache:
+                - false
+                - true
+          pre-steps:
+            - node/install-rosetta
+          post-steps:
+            - run:
+                command: 'echo "Installed version: $(node -v)" && echo "Expected version: v$(cat ~/.node-js-version)" && [ $(node -v) = "v$(cat ~/.node-js-version)" ]'
+                name: Confirm Version
+            - run:
+                command: 'echo "Installed arch: $(node -p "process.arch === \"x64\" ? \"x86_64\" : process.arch")" && echo "Expected arch: << matrix.arch >>" && [ $(node -p "process.arch === \"x64\" ? \"x86_64\" : process.arch") = "<< matrix.arch >>" ]'
+                name: Confirm Arch
       - install-rosetta:
           filters: *filters
           matrix:
@@ -184,6 +260,29 @@ workflows:
               use-test-steps:
                 - false
                 - true
+      - run-tests:
+          filters: *filters
+          matrix:
+            alias: run-tests-with-arch
+            parameters:
+              arch:
+                - arm64
+                - x86_64
+              cache-version:
+                - v3
+              executor:
+                - node/macos
+              node-version:
+                - 18.14.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
+              use-test-steps:
+                - false
+                - true
+          pre-steps:
+            - node/install-rosetta
       - node/test:
           app-dir: ~/project/sample
           filters: *filters
@@ -228,6 +327,53 @@ workflows:
                   - run:
                       command: '[ -f ~/project/sample/.custom-test-ran ]'
                       name: Confirm Custom Test Steps Ran
+      - node/test:
+          name: node/test-<< matrix.arch >>-<< matrix.cache-version >>-<< matrix.executor >>-<< matrix.node-version >>-<< matrix.use-test-steps >>
+          app-dir: ~/project/sample
+          filters: *filters
+          matrix:
+            alias: run-tests-job-with-arch
+            parameters:
+              arch:
+                - arm64
+                - x86_64
+              cache-version:
+                - v3
+              executor:
+                - node/macos
+              node-version:
+                - 18.14.0
+                - '16.19'
+                - '16'
+                - latest
+                - lts
+              use-test-steps:
+                - false
+                - true
+          test-steps:
+            - run: echo '1' > ~/project/sample/.custom-test-ran
+          post-node-js-install-steps:
+            - run:
+                command: '[ ! -d ~/project/sample/node_modules ]'
+                name: Confirm Packages Aren't Installed Yet
+          pre-steps:
+            - node/install-rosetta
+            - run:
+                command: '[ ! -f ~/project/sample/.test-ran ]'
+                name: Confirm Tests Haven't Run Yet
+          post-steps:
+            - unless:
+                condition: << matrix.use-test-steps >>
+                steps:
+                  - run:
+                      command: '[ -f ~/project/sample/.test-ran ]'
+                      name: Confirm Tests Ran
+            - when:
+                condition: << matrix.use-test-steps >>
+                steps:
+                  - run:
+                      command: '[ -f ~/project/sample/.custom-test-ran ]'
+                      name: Confirm Custom Test Steps Ran
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
           filters: *release-filters
@@ -239,9 +385,13 @@ workflows:
           requires:
             - orb-tools/pack
             - check-version
+            - check-version-with-arch
             - install-rosetta
             - check-version-job
+            - check-version-job-with-arch
             - run-tests
+            - run-tests-with-arch
             - run-tests-job
+            - run-tests-job-with-arch
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -2,6 +2,12 @@ description: >
   Install specified Node.js version.
 
 parameters:
+  arch:
+    default: ""
+    description: >
+      Arch to use for executing the Bash script - only supported for installing
+      x86_64 Node.js on macOS ARM64 (must install Rosetta first).
+    type: string
   cache-version:
     default: v1
     description: >
@@ -35,15 +41,29 @@ steps:
       condition: << parameters.with-cache >>
       steps:
         - restore_cache:
-            key: node-js-<<parameters.cache-version>>-{{ arch }}-{{ checksum "~/.nvm-version" }}-{{ checksum "~/.node-js-version" }}
+            key: node-js-<<parameters.cache-version>>-<< parameters.arch >>-{{ arch }}-{{ checksum "~/.nvm-version" }}-{{ checksum "~/.node-js-version" }}
         - run:
             command: <<include(scripts/restore-node-js-cache.sh)>>
             name: Restore cached Node.js
-  - run:
-      command: <<include(scripts/install-node.sh)>>
-      environment:
-        NODE_PARAM_VERSION: <<parameters.node-version>>
-      name: Install Node.js <<parameters.node-version>>
+  - when:
+      condition:
+        not: << parameters.arch >>
+      steps:
+        - run:
+            command: <<include(scripts/install-node.sh)>>
+            environment:
+              NODE_PARAM_VERSION: <<parameters.node-version>>
+            name: Install Node.js <<parameters.node-version>>
+  - when:
+      condition: << parameters.arch >>
+      steps:
+        - run:
+            command: <<include(scripts/install-node.sh)>>
+            environment:
+              ARCHPREFERENCE: <<parameters.arch>>
+              NODE_PARAM_VERSION: <<parameters.node-version>>
+            name: Install Node.js <<parameters.node-version>> (<<parameters.arch>>)
+            shell: arch /bin/bash
   - when:
       condition: << parameters.with-cache >>
       steps:
@@ -51,7 +71,7 @@ steps:
             command: <<include(scripts/prepare-node-js-cache.sh)>>
             name: Prepare Node.js cache
         - save_cache:
-            key: node-js-<<parameters.cache-version>>-{{ arch }}-{{ checksum "~/.nvm-version" }}-{{ checksum "~/.node-js-version" }}
+            key: node-js-<<parameters.cache-version>>-<< parameters.arch >>-{{ arch }}-{{ checksum "~/.nvm-version" }}-{{ checksum "~/.node-js-version" }}
             paths:
              - ~/.node-js-cache
   - when:

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -8,6 +8,12 @@ parameters:
       Path to the directory containing your package.json file. Not needed if
       package.json lives in the root.
     type: string
+  arch:
+    default: ""
+    description: >
+      Arch to use for executing the Bash script - only supported for installing
+      x86_64 Node.js on macOS ARM64 (must install Rosetta first).
+    type: string
   cache-version:
     default: v1
     description: >
@@ -68,6 +74,7 @@ steps:
         equal: [ yarn, << parameters.pkg-manager >> ]
       steps:
         - install:
+            arch: << parameters.arch >>
             cache-version: << parameters.cache-version >>
             install-yarn: true
             node-version: << parameters.node-version >>
@@ -77,6 +84,7 @@ steps:
         equal: [ npm, << parameters.pkg-manager >> ]
       steps:
         - install:
+            arch: << parameters.arch >>
             cache-version: << parameters.cache-version >>
             install-yarn: false
             node-version: << parameters.node-version >>

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -4,6 +4,12 @@ description: >
 executor: <<parameters.executor>>
 
 parameters:
+  arch:
+    default: ""
+    description: >
+      Arch to use for executing the Bash script - only supported for installing
+      x86_64 Node.js on macOS ARM64 (must install Rosetta first).
+    type: string
   cache-version:
     default: v1
     description: >
@@ -29,6 +35,7 @@ parameters:
 
 steps:
   - install:
+      arch: << parameters.arch >>
       cache-version: << parameters.cache-version >>
       install-yarn: << parameters.install-yarn >>
       node-version: << parameters.node-version >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -10,6 +10,12 @@ parameters:
       Path to the directory containing your package.json file. Not needed if
       package.json lives in the root.
     type: string
+  arch:
+    default: ""
+    description: >
+      Arch to use for executing the Bash script - only supported for installing
+      x86_64 Node.js on macOS ARM64 (must install Rosetta first).
+    type: string
   cache-version:
     default: v1
     description: >
@@ -69,6 +75,7 @@ parameters:
 steps:
   - test:
       app-dir: << parameters.app-dir >>
+      arch: << parameters.arch >>
       cache-version: << parameters.cache-version >>
       checkout-steps: << parameters.checkout-steps >>
       node-version: << parameters.node-version >>

--- a/src/scripts/install-node.sh
+++ b/src/scripts/install-node.sh
@@ -1,3 +1,13 @@
+# These are the default options CircleCI uses, but they may
+# not be set if we're running under Rosetta, so set them now
+set -eo pipefail
+
+# Similarly, nvm may not be set up under a Rosetta terminal
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # shellcheck disable=SC1091
+    source "${NVM_DIR}/nvm.sh";
+fi
+
 if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     # See: https://github.com/coreybutler/nvm-windows#usage
     if [ -n "$NODE_PARAM_VERSION" ]; then


### PR DESCRIPTION
Let's you specify the arch for the Node.js install. Only tested on macOS at the moment for installing x86_64 on Apple Silicon via Rosetta. Might be possible to make it work on Linux as well but there's not much reason (CircleCI has Linux ARM64 executors) - the use case for this is when we want to test Intel macOS after CircleCI sunsets those executors in June.