### PR TITLE
fix: pin Windows executor to known good image

### DIFF
--- a/src/executors/windows.yml
+++ b/src/executors/windows.yml
@@ -2,6 +2,6 @@ description: >
   Windows executor.
 
 machine:
-  image: windows-server-2022-gui:current
+  image: windows-server-2022-gui:2023.11.1
   resource_class: windows.medium
   shell: bash.exe


### PR DESCRIPTION
`windows-server-2022-gui:2024.01.1` regressed from `nvm-windows` 1.1.11 to 1.1.9 - we need 1.1.11+ for bug fixes and `major.minor` version syntax support.