### PR TITLE
fix: switch back to current Windows image tag

### DIFF
--- a/src/executors/windows.yml
+++ b/src/executors/windows.yml
@@ -2,6 +2,6 @@ description: >
   Windows executor.
 
 machine:
-  image: windows-server-2022-gui:2023.11.1
+  image: windows-server-2022-gui:current
   resource_class: windows.medium
   shell: bash.exe


### PR DESCRIPTION
CircleCI promoted `:2024.04.1` to `:current` so we can switch this back now and get off the deprecated image.