### PR TITLE
fix: use nvm --version to support older NVM versions

### DIFF
--- a/src/scripts/install-nvm.sh
+++ b/src/scripts/install-nvm.sh
@@ -28,5 +28,5 @@ else
     fi
 
     # Store the version so cache keys can easily use it
-    nvm -v > ~/.nvm-version;
+    nvm --version > ~/.nvm-version;
 fi


### PR DESCRIPTION
Older NVM versions don't support the `nvm -v` shorthand so use `nvm --version` which should work on all versions.