### PR TITLE
fix: resolve Node.js version when partial version is prefix of another

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,7 +24,7 @@ cache-version: &cache-version
 
 node-versions: &node-versions
   - 20.11.1
-  - '18.19'
+  - '18.1'
   - '16'
   - latest
   - lts

--- a/src/scripts/resolve-node-js-version.sh
+++ b/src/scripts/resolve-node-js-version.sh
@@ -27,7 +27,7 @@ elif [ -n "$NODE_PARAM_VERSION" ]; then
         ;;
 
       *)
-        RESOLVED_VERSION=$(curl -fs "$NODE_RELEASES" | grep -Eo "\"version\":\s*\"v${NODE_PARAM_VERSION}[.0-9]*\"" - | grep -Eo "$VERSION_NUMBER_REGEX" | $SORT -V | tail -n1)
+        RESOLVED_VERSION=$(curl -fs "$NODE_RELEASES" | grep -Eo "\"version\":\s*\"v${NODE_PARAM_VERSION}(.[0-9]+)*\"" - | grep -Eo "$VERSION_NUMBER_REGEX" | $SORT -V | tail -n1)
         ;;
     esac
 else


### PR DESCRIPTION
This went undetected until it popped up on `electron/lint-roller` CI where it was trying to install Node.js 20.1 which started failing after 20.10.0 was released. After the release of 20.10.0, the previous version of the regex would resolve 20.1 to 20.10.0 instead of the intended 20.1.0. Small improvement to the regex fixes the issue, and I've updated the test versions on this repo to use 18.1 so that we have test coverage of the issue.